### PR TITLE
Adjust table formatting for GitHub pages

### DIFF
--- a/DATA-DICTIONARY.md
+++ b/DATA-DICTIONARY.md
@@ -1,10 +1,11 @@
 # RESO Data Dictionary Endorsement
 
-| **Version** | **1.7.0** |
+| **Version** | 1.7.0 |
 | :--- | :--- |
-| **Submitted By** | [Joshua Darnell](mailto:josh@reso.org) |
+| **Submitter** | [Joshua Darnell](mailto:josh@reso.org) |
 | **Written** | June 2020 |
 | **Ratified** | December 2020 |
+| **RCP** | RCP-038 |
 | **Related RCPs** | [Web API Core 2.0.0](https://github.com/RESOStandards/reso-transport-specifications/blob/main/WEB-API-CORE.md) |
 
 <br /><br />

--- a/RCP-TEMPLATE.md
+++ b/RCP-TEMPLATE.md
@@ -1,12 +1,13 @@
-# RESO RCP Endorsement Template
-|     |     |
-| --- | --- |
+# RESO (Endorsement Name) Endorsement
+
 | **Version** | x.y.z |
+| :--- | :--- |
 | **Submitter** | [Name of Author](mailto:your@company.com) |
 | **Co-Submitter** | [Name of Author](mailto:your@company.com) |
 | **Written** | June 2020 |
 | **Ratified** | December 2020 |
-| **Related RCPs** | [Related RCP](https://github.com/RESOStandards/reso-transport-specifications) |
+| **RCP** | RCP-XYZ |
+| **Related RCPs** | [Related RCP](https://transport.reso.org) |
 
 <br /><br />
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,13 @@ RESO Endorsements use [Semantic Versioning](https://semver.org/).
 The following proposals use the RESO Web API as a transport mechansim.
 
 ## [Data Dictionary Endorsement](./DATA-DICTIONARY.md)
-**Current Version**: 1.7
-**Status**: Adopted
+**Status**: Adopted, **Current Version**: 1.7
 
 The Data Dictionary endorsement defines models for use in the RESO domain. These include Resources, Fields, Lookups, and Relationships between Resources.
 
 ## [Web API Core Endorsement](./WEB-API-CORE.md)
 
-**Current Version**: 2.0.0
-**Status**: Adopted
+**Status**: Adopted, **Current Version**: 2.0.0
 
 The Web API Core endorsement defines the primary functionality RESO Web API servers are expected to have in order to provide both replication and live query support.
 

--- a/WEB-API-CORE.md
+++ b/WEB-API-CORE.md
@@ -1,11 +1,13 @@
 # RESO Web API Core Specification
-|     |     |
-| --- | --- |
+
 | **Version** | 2.0.0 |
+| :--- | :--- |
 | **Submitter** | [Joshua Darnell](mailto:josh@reso.org) |
 | **Written** | August 2020 |
 | **Ratified** | August 2020 |
+| **RCP** | RCP-037 |
 | **Related RCPs** | [Data Dictionary Endorsement](/DATA-DICTIONARY.md) |
+
 
 <br />
 


### PR DESCRIPTION
GitHub Pages wants a blank line before tables. Added the version as the top most thing since it's important there and updated templates with RCP numbers.